### PR TITLE
Added Code for Shell Sort, closes #637

### DIFF
--- a/C++/ShellSort.cpp
+++ b/C++/ShellSort.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+using namespace std;
+
+void ShellSort(int *A, int n)
+{
+    int gap, i , j, temp;
+
+    for ( gap = n/2; gap >= 1; gap/=2) // this loop control the passes
+    {
+        for ( i = gap; i < n; i++)
+        {
+            temp = A[i];
+            j = i - gap;
+            // For shifting all the elements
+            while (j >= 0 && A[j] > temp)
+            {
+                A[j+gap] = A[j];
+                j = j - gap;
+            }
+            A[j+gap] = temp;
+        }
+    }
+}
+
+int main()
+{
+    int A[] = {3, 7, 3, 10, 6, 6, 12, 4, 11, 2}, n = 10;
+    ShellSort(A, n);
+    for (int i = 0; i < n - 1; i++)
+    {
+        cout << A[i] << " ";
+    }
+    cout << endl;
+    return 0;
+}


### PR DESCRIPTION
Fixes #637

Shellsort, also known as Shell sort or Shell's method, is an in-place comparison sort. It can be seen as either a generalization of sorting by exchange (bubble sort) or sorting by insertion (insertion sort). The method starts by sorting pairs of elements far apart from each other, then progressively reducing the gap between elements to be compared. By starting with far apart elements, it can move some out-of-place elements into the position faster than a simple nearest-neighbor exchange.

## Type of change
- Added New code
# Checklist:

-   [x] I have read the contribution guidelines before making this PR.
-   [x] I have performed a self-review of my own code
